### PR TITLE
fix serialization for updateCase

### DIFF
--- a/src/api/ZephyrClient.kt
+++ b/src/api/ZephyrClient.kt
@@ -5,6 +5,7 @@ import com.github.kittinunf.fuel.Fuel
 import com.github.kittinunf.fuel.core.*
 import com.github.kittinunf.fuel.core.extensions.authentication
 import com.github.kittinunf.fuel.core.extensions.jsonBody
+import com.github.kittinunf.fuel.jackson.objectBody
 import com.github.kittinunf.fuel.jackson.responseObject
 import data.tms.*
 import mu.KotlinLogging
@@ -102,8 +103,9 @@ class ZephyrClient(private val apiKey: String) {
         log.info { "Will set [${updatedCase.key}] labels to [${updatedCase.labels}]" }
         log.debug { mapper.writeValueAsString(updatedCase) }
         val (request, response, _) = Fuel.put("$api/testcases/${updatedCase.key}")
-            .authentication().bearer(apiKey)
-            .jsonBody(mapper.writeValueAsString(updatedCase))
+            .authentication()
+                .bearer(apiKey)
+            .objectBody(updatedCase)
             .response()
         responseHandler(request, response)
     }


### PR DESCRIPTION
fix serialization for updateCase, because of errors: 
`Error updating test case: ErrorResponse(errorCode=400, message=When custom fields are present in the request body for this endpoint, then all custom fields should be present as well. If you wish to leave any of them blank, please set them null if they are not required custom fields. The custom fields expected to be present in the request body are: Android Auto, Comment, Type, iOS Auto, status=Bad Request)`